### PR TITLE
minor fix in comments of 'get_path_indices()'

### DIFF
--- a/src/policy_gradients/torch_utils.py
+++ b/src/policy_gradients/torch_utils.py
@@ -208,7 +208,7 @@ def get_path_indices(not_dones):
     tensor([[1, 1, 0, 1, 1, 1, 1, 1, 1, 1],
             [1, 1, 0, 1, 1, 0, 1, 1, 0, 1]], dtype=torch.uint8)
     Then we would return:
-    [(0, 0, 3), (0, 3, 10), (1, 0, 3), (1, 3, 5), (1, 5, 9), (1, 9, 10)]
+    [(0, 0, 3), (0, 3, 10), (1, 0, 3), (1, 3, 6), (1, 6, 9), (1, 9, 10)]
     """
     indices = []
     num_timesteps = not_dones.shape[1]


### PR DESCRIPTION
A minor error on the example indices. Fix for clarity.

The second line with indices:
`[1, 1, 0, 1, 1, 0, 1, 1, 0, 1]`
`[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]`